### PR TITLE
Add a basic configuration using EP internal GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,19 @@
+#####################
+## Pipeline stages
+#####################
+
+stages:
+  - build
+  - test
+
+############################
+## Jobs for build stage
+############################
+
+build-server:
+  stage: build
+  needs: []
+  image: node:14-alpine
+  script:
+    - yarn install
+    - yarn build


### PR DESCRIPTION
This PR adds a basic CI configuration that based on GitLab CI. The CI environment is within Elastic Path internal infrastructure. This repository is already mirrored in that GitLab instance. Pushing commits to this repo will run the CI automatically.

As this repo is updated, the CI configuration can be enhanced to do more (i.e. running tests, deploying somewhere, etc.)
