### PR TITLE
chore (build): update tsconfig to fix build/compile errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,15 +14,16 @@
   },
   "dependencies": {
     "@moltin/sdk": "^6.6.0",
-    "dataloader": "^2.0.0",
     "apollo-server": "^2.24.0",
     "apollo-server-testing": "^2.24.0",
+    "dataloader": "^2.0.0",
     "dotenv": "^8.2.0",
     "graphql": "^15.5.0",
     "graphql-tools": "^7.0.5",
     "nodemon": "^2.0.7"
   },
   "devDependencies": {
+    "@tsconfig/node14": "^1.0.0",
     "dotenv": "^8.2.0",
     "graphql-cli": "^4.1.0",
     "nodemon": "^2.0.7",
@@ -44,6 +45,8 @@
     "node": "=14"
   },
   "nodemonConfig": {
-    "ignore": ["schema.graphql"]
+    "ignore": [
+      "schema.graphql"
+    ]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,13 @@
 {
+  "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
-    "target": "es5",
-    "moduleResolution": "node",
-    "module": "commonjs",
+    "strict": false,
+    "esModuleInterop": false,
     "sourceMap": true,
     "noUnusedLocals": true,
     "rootDir": "src",
     "outDir": "dist",
-    "lib": ["esnext.asynciterable", "es2016", "dom"]
+    "lib": ["esnext.asynciterable", "es2020", "dom"],
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1056,6 +1056,11 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@tsconfig/node14@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.0.tgz#5bd046e508b1ee90bc091766758838741fdefd6e"
+  integrity sha512-RKkL8eTdPv6t5EHgFKIVQgsDapugbuOptNd9OOunN/HAkzmmTnZELx1kNCK0rSdUYGmiFMM3rRQMAWiyp023LQ==
+
 "@types/accepts@*", "@types/accepts@^1.3.5":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.5.tgz#c34bec115cfc746e04fe5a059df4ce7e7b391575"


### PR DESCRIPTION
The project produces various errors when running 'yarn build'
command. The errors were mostly coming from 'node_modules' dir
even though it was being excluded. An additional config to skip
lib check needed to configured.

While looking to enabling 'skipLibCheck' config, decided to add
'@tsconfig/node14' package, which has some recommended configs
pre-configured including 'skipLibCheck'. Following recommended
configs needed to be disabled because they catch lots of errors
in our code, which will need to be addressed before they can be
enabled again.

- "strict": false
- "esModuleInterop": false