### PR TITLE
chore (ci): use elasticpath docker images in CI process

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,10 @@ stages:
 build-server:
   stage: build
   needs: []
-  image: node:14-alpine
+  image: quay.io/elasticpath/lang-node:14.16-b66be95e-21981
+  variables:
+    DOCKER_AUTH_CONFIG: |
+      {"auths":{"quay.io":{"auth":"${QUAY_DOCKER_AUTH_PARVEZ_AKKAS}"}}}
   script:
     - yarn install
     - yarn build


### PR DESCRIPTION
This change uses base images maintained by Elastic Path for the CI
process. The docker image is pulled from quay.io. Right now it is
using my personal token. When this project is officially setup, it
should be updated to use a more generic account with restricted
access. This change is also to illustrate that necessary CI secrets
can be managed in the GitLab mirror repo where CI is running.