### PR TITLE
chore: update tsconfig to follow node16 stack upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "nodemon": "^2.0.7"
   },
   "devDependencies": {
-    "@tsconfig/node14": "^1.0.0",
+    "@tsconfig/node16": "^1.0.1",
     "dotenv": "^9.0.2",
     "graphql-cli": "^4.1.0",
     "nodemon": "^2.0.7",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "strict": false,
     "esModuleInterop": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1056,10 +1056,10 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@tsconfig/node14@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.0.tgz#5bd046e508b1ee90bc091766758838741fdefd6e"
-  integrity sha512-RKkL8eTdPv6t5EHgFKIVQgsDapugbuOptNd9OOunN/HAkzmmTnZELx1kNCK0rSdUYGmiFMM3rRQMAWiyp023LQ==
+"@tsconfig/node16@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.1.tgz#a6ca6a9a0ff366af433f42f5f0e124794ff6b8f1"
+  integrity sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==
 
 "@types/accepts@*", "@types/accepts@^1.3.5":
   version "1.3.5"


### PR DESCRIPTION
This PR is a small clean up after the node stack of this repo was updated to use node 16.

Related PR: https://github.com/elasticpath/elasticpath-graphql-server/pull/19
