### PR TITLE
Switch to implicit token for SDK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,2 @@
 ELASTICPATH_CLIENT_ID=<your-client-id>
-ELASTICPATH_CLIENT_SECRET=<your-client-secret>
 ELASTICPATH_API_HOST=<your-api-host>

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,6 @@ postman-tests:
   image: node:16-alpine
   before_script:
     - echo "ELASTICPATH_CLIENT_ID=${ELASTICPATH_CLIENT_ID}" > .env
-    - echo "ELASTICPATH_CLIENT_SECRET=${ELASTICPATH_CLIENT_SECRET}" >> .env
     - echo "ELASTICPATH_API_HOST=${ELASTICPATH_API_HOST}" >> .env
   script:
     - yarn install

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Copy the `.env.example` file to create a `.env` file and fill in appropriate val
 
 ```bash
 export ELASTICPATH_CLIENT_ID=
-export ELASTICPATH_CLIENT_SECRET=
 export ELASTICPATH_API_HOST=
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,11 +6,10 @@ import resolvers from './resolvers'
 import loaders from './loaders'
 import { makeExecutableSchema } from '@graphql-tools/schema';
 
-const {ELASTICPATH_CLIENT_ID, ELASTICPATH_CLIENT_SECRET, ELASTICPATH_API_HOST} = process.env
+const {ELASTICPATH_CLIENT_ID, ELASTICPATH_API_HOST} = process.env
 
 export const Moltin = MoltinGateway({
     client_id: ELASTICPATH_CLIENT_ID,
-    client_secret: ELASTICPATH_CLIENT_SECRET,
     host: ELASTICPATH_API_HOST
 })
 


### PR DESCRIPTION
When passing the client_secret to the SDK it uses client-credentials tokens. It's better for us to use implicit token for shopping experience.