### PR TITLE
fix: update steps that builds the server app

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,36 @@ The workflow using `setNextRequest` allows us to control order of tests, to do t
 1. Getting a product by previously stored id. 
    
 For an example of tests, check out `products` and `product` within the Postman Collection.
+
+## Build & Deploy
+
+To build the server:
+
+1. Run `yarn build` and you'll have output in the `build/dist/` directory
+2. Run `yarn start` to run the server locally from that built output
+
+Deploying the server can be done in various ways. Checkout the [Apollo Documentation on deployment](https://www.apollographql.com/docs/apollo-server/deployment/) for suggestions on how to deploy it several cloud hosting services.
+
+Alternatively, you can copy the build output and host it yourself in a dedicated machine with NodeJS installed.
+
+Another alternative is to deploy in a kubernetes cluster by building a docker image:
+
+```dockerfile
+FROM node:16-alpine
+
+WORKDIR /app/
+
+COPY package.json .
+COPY yarn.lock .
+COPY build/dist/ .
+
+RUN yarn install
+
+EXPOSE 4000
+
+CMD ["node", "/app/"]
+```
+
+- Build the docker image: `docker build --tag epcc-graphql --file Dockerfile .`
+- Run the docke image with necessary configurations: `docker run --detach --name epcc-graphql -p 8000:4000 --env ELASTICPATH_API_HOST=api.moltin.com epcc-graphql`
+- GraphQL playground and apis should now be available at `localhost:8000/`

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "dev:server": "nodemon -e ts,graphql -x ts-node -r dotenv/config src",
     "playground": "graphql playground",
     "deploy": "now --public --dotenv .env.production && now alias && now rm --yes --safe moltinql",
-    "build": "rimraf dist && tsc",
-    "start": "node dist",
+    "compile": "rimraf build/dist && tsc",
+    "build": "yarn compile && cp src/types/*.graphql build/dist/types/",
+    "start": "node build/dist",
     "test": "node newman"
   },
   "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,9 +5,15 @@
     "esModuleInterop": false,
     "sourceMap": true,
     "noUnusedLocals": true,
+    "allowJs": true,
     "rootDir": "src",
-    "outDir": "dist",
+    "outDir": "build/dist",
     "lib": ["esnext.asynciterable", "es2020", "dom"],
   },
-  "exclude": ["node_modules", "dist"]
+  "exclude": [
+    "node_modules/",
+    "build/",
+    "newman-config.js",
+    "newman.js"
+  ]
 }


### PR DESCRIPTION
The current configuration of the project is able to start the
dev instance of the GraphQL server. However it fails to start
when it is built. The failure is mostly due to mixed use of
typescript and non-typescript files. For example: the typedef
files are '.graphql' extension but they are not copied to the
final distibution.

```
yarn run v1.22.5
$ node dist
node:internal/modules/cjs/loader:944
  throw err;
  ^

Error: Cannot find module './types'
Require stack:
- /Users/pakkas/gitProjects/github.com/elasticpath/elasticpath-graphql-server/dist/index.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:941:15)
    at Function.Module._load (node:internal/modules/cjs/loader:774:27)
    at Module.require (node:internal/modules/cjs/loader:1013:19)
    at require (node:internal/modules/cjs/helpers:93:18)
    at Object.<anonymous> (/Users/pakkas/gitProjects/github.com/elasticpath/elasticpath-graphql-server/dist/index.js:4:17)
    at Module._compile (node:internal/modules/cjs/loader:1109:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1138:10)
    at Module.load (node:internal/modules/cjs/loader:989:32)
    at Function.Module._load (node:internal/modules/cjs/loader:829:14)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:76:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/pakkas/gitProjects/github.com/elasticpath/elasticpath-graphql-server/dist/index.js'
  ]
}
error Command failed with exit code 1.
```

Applied necessary configurations to both tsconfig as well as
build config. Added instructions into Readme on how to build
the non-dev version of the server as well as suggestions on
several deployment options.