### PR TITLE
chore (ci): use the build output in test stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,18 +17,26 @@ build-server:
   script:
     - yarn install
     - yarn build
+  artifacts:
+    when: always
+    expire_in: 3 days
+    name: ${CI_PROJECT_PATH_SLUG}-${CI_COMMIT_REF_SLUG}-${CI_PIPELINE_ID}-${CI_JOB_NAME}
+    paths:
+      - build/dist
 
 postman-tests:
   stage: test
-  needs: []
+  needs:
+    - build-server
   image: node:16-alpine
   variables:
     ELASTICPATH_CLIENT_ID: $ELASTICPATH_CLIENT_ID
     ELASTICPATH_API_HOST: $ELASTICPATH_API_HOST
-  script:
+  before_script:
     - yarn install
-    - yarn dev&
-    - sleep 5
+    - yarn start&
+    - sleep 5 ## Let the server start up
+  script:
     - yarn test
   artifacts:
     when: always


### PR DESCRIPTION
This PR updates the CI pipeline configuration. Currently the pipeline runs both build and test in parallel. But, now that we have fixed the build issue (PR #83 ), the test step in CI has been configured to depend on on the build stage. The test stage now starts the server from build result instead of starting the graphql server in local dev mode. This increases CI time a little bit but validates that the production build is still functional.
